### PR TITLE
Added ignoredErrorCodes to options for allow ignoring e.g. 401s

### DIFF
--- a/build/js/messenger.js
+++ b/build/js/messenger.js
@@ -3,7 +3,8 @@
   var $, ActionMessenger, MagicMessage, Message, Messenger, spinner_template,
     __hasProp = {}.hasOwnProperty,
     __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-    __slice = [].slice;
+    __slice = [].slice,
+    __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   $ = jQuery;
 
@@ -603,7 +604,7 @@
         var old, _ref1;
         old = (_ref1 = opts[type]) != null ? _ref1 : function() {};
         return opts[type] = function() {
-          var data, msgOpts, msgText, r, reason, resp, xhr, _ref2, _ref3, _ref4, _ref5, _ref6;
+          var data, msgOpts, msgText, r, reason, resp, xhr, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7;
           resp = 1 <= arguments.length ? __slice.call(arguments, 0) : [];
           _ref2 = _this._normalizeResponse.apply(_this, resp), reason = _ref2[0], data = _ref2[1], xhr = _ref2[2];
           if (type === 'success' && !(msg.errorCount != null) && m_opts.showSuccessWithoutError === false) {
@@ -620,15 +621,19 @@
             msg.hide();
             return;
           }
+          if (type === 'error' && (_ref4 = xhr != null ? xhr.status : void 0, __indexOf.call(m_opts['ignoredErrorCodes'], _ref4) >= 0)) {
+            msg.hide();
+            return;
+          }
           if (msgText) {
             msgOpts = $.extend({}, m_opts, {
               message: msgText,
               type: type,
-              events: (_ref4 = events[type]) != null ? _ref4 : {},
+              events: (_ref5 = events[type]) != null ? _ref5 : {},
               hideOnNavigate: type === 'success'
             });
             if (type === 'error' && (xhr != null ? xhr.status : void 0) >= 500) {
-              if ((_ref5 = msgOpts.retry) != null ? _ref5.allow : void 0) {
+              if ((_ref6 = msgOpts.retry) != null ? _ref6.allow : void 0) {
                 if (msgOpts.retry.delay == null) {
                   if (msgOpts.errorCount < 4) {
                     msgOpts.retry.delay = 10;
@@ -637,7 +642,7 @@
                   }
                 }
                 if (msgOpts.hideAfter) {
-                  if ((_ref6 = msgOpts._hideAfter) == null) {
+                  if ((_ref7 = msgOpts._hideAfter) == null) {
                     msgOpts._hideAfter = msgOpts.hideAfter;
                   }
                   msgOpts.hideAfter = msgOpts._hideAfter + msgOpts.retry.delay;

--- a/src/coffee/messenger.coffee
+++ b/src/coffee/messenger.coffee
@@ -498,6 +498,11 @@ class ActionMessenger extends Messenger
                     do msg.hide
                     return
 
+                if type is 'error' and (xhr?.status in m_opts['ignoredErrorCodes'])
+                    # We're ignoring this error
+                    do msg.hide
+                    return
+
                 if msgText
                     msgOpts = $.extend {}, m_opts,
                         message: msgText


### PR DESCRIPTION
This is especially useful for hooking into Backbone. In my app, for example, I pop a login modal on 401. I don't need messenger to pop as well:

``` javascript
$.globalMessenger().hookBackboneAjax({
  errorMessage: "Error contacting server. Please try again.",
  ignoredErrorCodes: [401]
});
```
