### PR TITLE
Fixes for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,11 +11,9 @@
     "toast",
     "ajax"
   ],
-  "scripts": [
+  "main": [
     "build/js/messenger.js",
-    "build/js/messenger-theme-future.js"
-  ],
-  "styles": [
+    "build/js/messenger-theme-future.js",
     "build/css/messenger.css",
     "build/css/messenger-theme-future.css",
     "build/css/messenger-theme-block.css",
@@ -23,12 +21,16 @@
     "build/css/messenger-theme-ice.css"
   ],
   "dependencies": {
-    "component/jquery": "*"
+    "jquery": "*"
   },
-  "main": "build/js/messenger.js",
   "ignore": [
     "**/.*",
-    "node_modules",
-    "components"
+    "component.json",
+    "Gruntfile.coffee",
+    "lib/",
+    "package.json",
+    "SpecRunner.html",
+    "spec/",
+    "src/"
   ]
 }


### PR DESCRIPTION
- Fix jquery dependency
- Include all production files in `main`
- Ignore everything else

Refs #39

I'm pretty new to all this JS packaging stuff, but it seems like currently people tend to maintain two repositories for dealing with bower, with a bower-specific repository that contains only the built version and a `bower.json`.  That seems like a whole lot of wasted effort, so I don't know if you want to go that far, hopefully that gets resolved after the bower rewrite is finished.  For now I've just fixed made the above changes so that it works - though files are still deployed to messenger/build/(js|css) - and doesn't ship all the extra stuff like libs and source.  All in all, bower still seems a little confused about what `main` is actually meant to be currently, so, I've just made sure it references everything required.

I don't know if this is expected to work with JQuery 2.0.0, but if not, it might also be worth adding a dependency restriction to `~1.9.1`
