### PR TITLE
Gh pages remove bootstrap js

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
     <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
     <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.3/underscore-min.js"></script>
     <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/backbone.js/0.9.10/backbone-min.js"></script>
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.2.2/bootstrap.min.js"></script>
     <script type="text/javascript" src="build/js/messenger.js"></script>
     <script type="text/javascript" src="build/js/messenger-theme-future.js"></script>
 


### PR DESCRIPTION
@zackbloom we don't need this here anymore, correct?

Note: I already removed bootstrap styles with https://github.com/HubSpot/messenger/commit/541645aeacafedc4d8fd5f132a5aa9139243ad3e and https://github.com/HubSpot/messenger/commit/b90ac8b54427e1984f77abdf69731ac21e98490c.
