### PR TITLE
Add cursor: pointer style to .messenger-clickable elements

### DIFF
--- a/src/sass/messenger.sass
+++ b/src/sass/messenger.sass
@@ -77,3 +77,6 @@ ul.messenger
 
   .messenger-spinner
     display: none // Default theme doesn't use the spinner
+
+  .messenger-clickable
+    cursor: pointer


### PR DESCRIPTION
This seems pretty straightforward to me: A `.messenger-clickable` is clickable, and clickable things should have `cursor: pointer`, right?
