### PR TITLE
add main in pacakge.json to support webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.5.0",
   "license": "MIT",
   "homepage": "http://github.hubspot.com/messenger",
+  "main": "build/js/messenger.js",
   "authors": [
     "Zack Bloom <zackbloom@gmail.com>",
     "Adam Schwartz <adam.flynn.schwartz@gmail.com>"


### PR DESCRIPTION
Without this, we have to  impoirt like this, `require ("messenger/build/js/messenger");`

while after, `require('messenger')` or  `import Messenger from 'messenger'` can work more simply.