### PR TITLE
docs: Fix simple typo, specifing -> specifying

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -102,7 +102,7 @@ Adding the `top` or `bottom` class along with a `left` or `right` will move the 
 - `parentLocations`: Which locations should be tried when inserting the message container into the page.  The default is `['body']`.
 It accepts a list to allow you to try a variety of places when deciding what the optimal location is on any given page.  This should
 generally not need to be changed unless you are inserting the messages into the flow of the document, rather than using `messenger-fixed`.
-- `theme`: What theme are you using? Some themes have associated javascript, specifing this allows that js to run.
+- `theme`: What theme are you using? Some themes have associated javascript, specifying this allows that js to run.
 - `messageDefaults`: Default options for created messages
 
 ```javascript

--- a/spec/lib/jquery-1.9.1.js
+++ b/spec/lib/jquery-1.9.1.js
@@ -6836,7 +6836,7 @@ jQuery.extend({
 				value += "px";
 			}
 
-			// Fixes #8908, it can be done more correctly by specifing setters in cssHooks,
+			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 			// but it would mean to define eight (for every problematic property) identical functions
 			if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 				style[ name ] = "inherit";


### PR DESCRIPTION
There is a small typo in docs/intro.md, spec/lib/jquery-1.9.1.js.

Should read `specifying` rather than `specifing`.

